### PR TITLE
Add build and push docker image action

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,6 +30,19 @@ jobs:
 
     - name: Build optimized binary
       run: cargo build --release --verbose
+    
+    - name: Build and push Docker image
+      if: matrix.os == 'ubuntu-latest'
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        repository: airalab/robonomics
+        tag_with_ref: true
+        tags: latest
+        add_git_labels: true
+        dockerfile: scripts/docker/Dockerfile
+        path: target/release
 
     - name: Upload binary archive into IPFS
       if: runner.os != 'Windows'


### PR DESCRIPTION
1. You need to create repo at http://hub.docker.com/ which you need to update in action (I've set it to airalab/robonomics, so the new one could differ)
2. Create a Personal Access Token, so we can push images https://hub.docker.com/settings/security
3. Add secrets to GitHub Repo https://github.com/airalab/robonomics/settings/secrets
DOCKER_USERNAME for username
DOCKER_PASSWORD add created PAT here
4. After committing changes to workflow, a new push to tag will execute this action, build the image, and push to docker hub. The new image will be tagged with: latest and v*.. tag version.

This PR closes #70 