### PR TITLE
Added JSONRPC 2.0 spec

### DIFF
--- a/protocol/src/pubsub/spec.json
+++ b/protocol/src/pubsub/spec.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "pubsub_peer",
+    "returns": "String"
+  },
+  {
+    "name": "pubsub_listen",
+    "params": {
+        "address": "Multiaddr"
+    },
+    "returns": true
+  },
+  {
+    "name": "pubsub_listeners",
+    "returns": ["Multiaddr"]
+  },
+  {
+    "name": "pubsub_connect",
+    "params": {
+        "address": "Multiaddr"
+    },
+    "returns": true
+  },
+  {
+    "name": "pubsub_publish",
+    "params": {
+        "topic_name": "String",
+        "message": "String"
+    },
+    "returns": true
+  }
+]


### PR DESCRIPTION
This is a JSONRPC spec that describes the pubsub API (for its use with libjson-rpc-cpp)