### PR TITLE
Fix path to crates.robonomics.network docs index page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
       run: nix-shell --run "cargo doc --workspace --no-deps"
 
     - name: Push index.html
-      run: echo "<meta http-equiv=\"refresh\" content=\"0; URL='./robonomics_protocol/index.html'\" />" > ./target/doc/index.html
+      run: echo "<meta http-equiv=\"refresh\" content=\"0; URL='./robonomics/index.html'\" />" > ./target/doc/index.html
 
     - name: Deploy crates.robonomics.network
       uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Now http://crates.robonomics.network returns 404, because url refers to not existing path - `./robonomics_protocol/index.html`.
I tested locally this fix and it does works well