### PR TITLE
Fix docker build script

### DIFF
--- a/scripts/docker/build-docker.sh
+++ b/scripts/docker/build-docker.sh
@@ -37,7 +37,7 @@ fi
 time docker build -f ./Dockerfile --build-arg RUSTC_WRAPPER= --build-arg PROFILE=release --build-arg TARGETARCH=$ARCH -t robonomics/robonomics:latest .
 
 # cleanup binary file
-rm robonomics
+rm -r ${ARCH}
 
 # Show the list of available images for this repo
 echo "Image is ready"

--- a/scripts/docker/build-docker.sh
+++ b/scripts/docker/build-docker.sh
@@ -34,7 +34,7 @@ then
 else
     echo "If not first build, proceed to docker-compose build and run"
 fi
-time docker build -f ./Dockerfile --build-arg RUSTC_WRAPPER= --build-arg PROFILE=release -t robonomics/robonomics:latest .
+time docker build -f ./Dockerfile --build-arg RUSTC_WRAPPER= --build-arg PROFILE=release --build-arg TARGETARCH=$ARCH -t robonomics/robonomics:latest .
 
 # cleanup binary file
 rm robonomics


### PR DESCRIPTION
Due to `TARGETOS` being used in `Dockerfile` to obtain the `robonomics` binary from build context, the build script should pass it. Currently, it fails with an error following.

```console
...
Step 13/18 : COPY $TARGETARCH/robonomics /usr/local/bin
COPY failed: file not found in build context or excluded by .dockerignore: stat robonomics: file does not exist
```

This PR adds passing `TARGETOS` to the docker build.

Also, the build script copies the `robonomics` binary to the build context, but cleanup fails due to its path is not the same as the copying path. This PR fixes it too.