### PR TITLE
Fix the health check procedure

### DIFF
--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -28,14 +28,13 @@ RUN apt-get update && \
 	mkdir -p /robonomics/.local/share && \
 	mkdir /data && \
 	chown -R robonomics:robonomics /data && \
-	ln -s /data /robonomics/.local/share/robonomics && \
-	rm -rf /usr/bin /usr/sbin
+	ln -s /data /robonomics/.local/share/robonomics
 
 COPY ./healthcheck.sh /usr/bin/
 HEALTHCHECK --interval=300s --timeout=75s --start-period=30s --retries=3 \
     CMD ["/usr/bin/healthcheck.sh"]
 
-LABEL description="This is the 2nd stage: a very small image where we copy the robonomics binary"
+LABEL description="This is the 2nd stage: an image where we copy the robonomics binary"
 
 ARG PROFILE=release
 # add binary to docker image

--- a/scripts/docker/healthcheck.sh
+++ b/scripts/docker/healthcheck.sh
@@ -3,8 +3,8 @@
 set -e
 
 head () {
-    polkadot-js-api --ws ws://127.0.0.1:9944 query.parachains.heads 100 |\
-        jq -r .heads
+    polkadot-js-api --ws ws://127.0.0.1:9944 query.system.number |\
+        jq -r .number
 }
 
 start=$(head)

--- a/scripts/docker/healthcheck.sh
+++ b/scripts/docker/healthcheck.sh
@@ -3,7 +3,8 @@
 set -e
 
 head () {
-    polkadot-js-api --ws ws://127.0.0.1:9944 query.system.number |\
+    polkadot-js-api --ws ws://127.0.0.1:9944 query.system.number 2>/dev/null |\
+        tail -3 |\
         jq -r .number
 }
 

--- a/scripts/docker/healthcheck.sh
+++ b/scripts/docker/healthcheck.sh
@@ -3,7 +3,7 @@
 set -e
 
 head () {
-    polkadot-js-api --ws ws://172.28.1.1:9944 query.parachains.heads 100 |\
+    polkadot-js-api --ws ws://127.0.0.1:9944 query.parachains.heads 100 |\
         jq -r .heads
 }
 


### PR DESCRIPTION
Currently, the node status reported by the docker image is always `unhealthy` because of the following reasons. The PR fixes the health check procedure. 

1. Health check procedure sends state queries to a static IP address.

    The PR suggests using the loopback where the node listens in all modes.

1. Querying `query.parachains.heads` always returns an error

    ```console
    Error: Cannot find query.parachains, your chain does not have the parachains pallet exposed in the runtime\n    at assert (/usr/lib/node_modules/@polkadot/api-cli/node_modules/@polkadot/util/cjs/assert.js:31:11)
    ```

    This PR suggests using `query.system.number` instead to consider a node unhealthy in case the node does not receive or produce new blocks.

    The idea of considering the node as unhealthy when it stays on the same block can be discussed because it may produce an unwanted behavior. For instance, RPC nodes may become unreachable during the events of consensus failure when the network may stop blocks producing too. But this is not a topic of discussion here while `query.system.number` implements the same idea as `query.parachains.heads` used before.

1. Dockerfile directive deletes directories with system binaries where it tries to copy `healthcheck.sh` later. Also, the script requires some system utils to work.

    The PR suggests preserving `/usr/bin` and `/usr/sbin` to let the health check work. It may make security concerns, but further improvements should be implemented in order to let the health check procedure work without system utilities. The accompanying growth of the image size from `744M` to `880M` does not look relatively large.